### PR TITLE
purple backend: Prevent Vcard-Req hang when "get_info" not implemented

### DIFF
--- a/backends/libpurple/main.cpp
+++ b/backends/libpurple/main.cpp
@@ -518,7 +518,11 @@ class SpectrumNetworkPlugin : public NetworkPlugin {
 				}
 				m_vcards[user + name] = id;
 
-				if (CONFIG_BOOL(config, "backend.no_vcard_fetch") && name != purple_account_get_username_wrapped(account)) {
+				PurplePlugin *prpl = purple_find_prpl_wrapped(purple_account_get_protocol_id_wrapped(account));
+				PurplePluginProtocolInfo *prpl_info = PURPLE_PLUGIN_PROTOCOL_INFO(prpl);
+				bool support_get_info = prpl_info && prpl_info->get_info;
+
+				if (!support_get_info || (CONFIG_BOOL(config, "backend.no_vcard_fetch") && name != purple_account_get_username_wrapped(account))) {
 					PurpleNotifyUserInfo *user_info = purple_notify_user_info_new_wrapped();
 					notify_user_info(purple_account_get_connection_wrapped(account), name.c_str(), user_info);
 					purple_notify_user_info_destroy_wrapped(user_info);
@@ -526,7 +530,6 @@ class SpectrumNetworkPlugin : public NetworkPlugin {
 				else {
 					serv_get_info_wrapped(purple_account_get_connection_wrapped(account), name.c_str());
 				}
-				
 			}
 		}
 


### PR DESCRIPTION
purple backend: Prevent hanging Vcard request when the plugin does not implement "get_info".

This affects e.g. the purple-facebook plugin. All VCard requests timeout after 60 seconds and no avatar (user picture) is fetched.
With this change the Vcard remains unpopulated (expected behaviour) but the avatars load.
